### PR TITLE
Memoized createstore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-store-provider",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Use React Hooks with mobx-state-tree",
   "homepage": "http://mobx-store-provider.overfoc.us/",
   "main": "lib/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Provider, useRef } from "react";
+import { Provider, useMemo } from "react";
 import { Identifier, Factory, MapStore } from "./types";
 import { retrieveStore, defaultId, identity, warning } from "./stores";
 
@@ -23,7 +23,7 @@ function createStore(factory: Factory): any {
   warning(
     "createStore is deprecated and will be removed, migrate to useCreateStore soon",
   );
-  return useRef(factory()).current;
+  return useMemo(factory, []);
 }
 
 /**
@@ -33,7 +33,7 @@ function createStore(factory: Factory): any {
  */
 function useCreateStore(factory: Factory): any;
 function useCreateStore(factory: Factory): any {
-  return useRef(factory()).current;
+  return useMemo(factory, []);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ function createStore(factory: Factory): any {
   warning(
     "createStore is deprecated and will be removed, migrate to useCreateStore soon",
   );
-  return useMemo(factory, []);
+  return useCreateStore(factory);
 }
 
 /**

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -4,7 +4,7 @@ import { Store, Identifier } from "./types";
 const stores: Map<Identifier, Store> = new Map();
 const defaultId: Identifier = Symbol("store");
 
-declare var process: {
+declare let process: {
   env: {
     NODE_ENV: string;
   };


### PR DESCRIPTION
This PR addresses #6 - `useMemo` now replaces `useRef` to memoize creation of models.